### PR TITLE
Added env stuff to simple deployment recipe

### DIFF
--- a/features/dashboard.theodi.org/dashboard.theodi.org.feature
+++ b/features/dashboard.theodi.org/dashboard.theodi.org.feature
@@ -76,6 +76,23 @@ dashboards ALL=NOPASSWD:ALL
   Scenario: nginx is installed
     * package "nginx" should be installed
 
+  Scenario: The env file exists
+    * file "/var/www/directory.theodi.org/shared/config/env" should exist
+
+  Scenario: The env file contains the correct stuff
+    When I run "cat /var/www/directory.theodi.org/shared/config/env"
+    Then I should see "JENKINS_URL: http://jenkins.theodi.org" in the output
+    And I should see "RESQUE_REDIS_HOST: 151" in the output
+    And I should see "EVENTBRITE_API_KEY: IZ" in the output
+    And I should see "CAPSULECRM_DEFAULT_OWNER: ri" in the output
+    And I should see "LEFTRONIC_GITHUB_OUTGOING_PRS: d" in the output
+    And I should see "COURSES_TARGET_URL: http:" in the output
+    And I should see "TRELLO_DEV_KEY: a1" in the output
+    And I should see "GITHUB_OUATH_TOKEN: 18" in the output
+    And I should see "GOOGLE_ANALYTICS_TRACKER: UA-3" in the output
+    And I should see "XERO_PRIVATE_KEY_PATH: /etc" in the output
+    And I should see "COURSES_RSYNC_PATH: json" in the output
+
   Scenario: Code is deployed
     * directory "/var/www/dashboards.theodi.org" should exist
     * directory "/var/www/dashboards.theodi.org/releases" should exist

--- a/site-cookbooks/odi-simple-deployment/recipes/default.rb
+++ b/site-cookbooks/odi-simple-deployment/recipes/default.rb
@@ -71,6 +71,41 @@ if [
       running_deploy_user       = new_resource.user
       bundler_depot             = new_resource.shared_path + '/bundle'
 
+      [
+          "database.yml"
+      ].each do |f|
+        p   = "%s/%s/%s" % [
+            current_release_directory,
+            "config",
+            f
+        ]
+        dbi = nil
+        file p do
+          action :create
+          begin
+            dbi = data_bag_item(
+                "%s" % [
+                    node['git_project']
+                ],
+                f.split('.').first
+            )
+
+            content dbi["content"].to_yaml
+
+          rescue Net::HTTPServerException
+          end
+        end
+      end
+
+      script 'Link me some links' do
+        interpreter 'bash'
+        cwd current_release_directory
+        user running_deploy_user
+        code <<-EOF
+        ln -sf ../../shared/config/env .env
+        EOF
+      end
+
       script 'Bundling the gems' do
         interpreter 'bash'
         cwd current_release_directory


### PR DESCRIPTION
At the moment, the Soundcloud and Scribd stuff on http://dashboards.theodi.org/ is borked because we don't get the env stuff from the data bags. Have cargo culted the stuff from the main recipe and added tests, but my testing environment is borked, so I can't run tests. 

Sure it'll be fine, but @pikesley can you run the tests on your machine for us? If all is well, please merge :)
