### PR TITLE
Run asset precompilation in production env

### DIFF
--- a/environments/experimental.rb
+++ b/environments/experimental.rb
@@ -1,0 +1,29 @@
+name 'experimental'
+
+default_attributes 'ENV'      => 'production',
+                   'RACK_ENV' => 'production',
+                   'chef_client' => {
+                       'server_url' => 'https://chef.theodi.org'
+                   },
+                   'deploy' => {
+                       'revision' => 'CURRENT'
+                   }
+
+cookbook 'apt', '= 1.9.0'
+cookbook 'build-essential', '= 1.3.4'
+cookbook 'envbuilder', '= 0.1.4'
+cookbook 'git', '= 2.3.0'
+cookbook 'imagemagick', '= 0.2.2'
+cookbook 'libcurl', '= 0.1.0'
+cookbook 'mysql', '= 2.1.2'
+cookbook 'nginx', '= 1.4.0'
+cookbook 'nodejs', '= 1.1.1'
+cookbook 'odi-deployment', '= 0.1.1'
+cookbook 'odi-nginx', '= 0.1.2'
+cookbook 'odi-rvm', '= 0.1.0'
+cookbook 'odi-users', '= 0.1.0'
+cookbook 'odi-xml', '= 0.1.0'
+cookbook 'redisio', '= 1.4.1'
+cookbook 'rvm', '= 0.0.2'
+cookbook 'sqlite', '= 0.1.0'
+cookbook 'xslt', '= 0.0.1'

--- a/site-cookbooks/odi-deployment/CHANGELOG.md
+++ b/site-cookbooks/odi-deployment/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of odi-deployment.
 
+## 0.1.1:
+
+* Run asset precompilation in production environment, for Rails 4.
+
 ## 0.1.0:
 
 * Initial release of odi-deployment

--- a/site-cookbooks/odi-deployment/metadata.rb
+++ b/site-cookbooks/odi-deployment/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'tech@theodi.org'
 license          'MIT'
 description      'Installs/Configures odi-deployment'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.1.1'
 
 depends 'git'

--- a/site-cookbooks/odi-deployment/recipes/default.rb
+++ b/site-cookbooks/odi-deployment/recipes/default.rb
@@ -172,7 +172,7 @@ if [
         cwd current_release_directory
         user running_deploy_user
         code <<-EOF
-        bundle exec rake assets:precompile
+        RAILS_ENV=production bundle exec rake assets:precompile
         EOF
         # Redis configuration not set!!!
       end


### PR DESCRIPTION
Because Rails 4 doesn't compile assets correctly unless you run it in production mode. I contend that this is a bug, but we can easily work around it by doing this. See rails/rails#10551 for the bug report I've filed.
