### PR TITLE
Add memcache config to drupal recipe

### DIFF
--- a/site-cookbooks/odi-website-deploy/CHANGELOG.md
+++ b/site-cookbooks/odi-website-deploy/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of odi-website-deploy.
 
+## 0.2.0:
+
+* Add support for memcache configuration
+
 ## 0.1.0:
 
 * Initial release of odi-website-deploy

--- a/site-cookbooks/odi-website-deploy/metadata.rb
+++ b/site-cookbooks/odi-website-deploy/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'tech@theodi.org'
 license          'MIT'
 description      'Installs/Configures odi-website-deploy'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.2.0'

--- a/site-cookbooks/odi-website-deploy/recipes/default.rb
+++ b/site-cookbooks/odi-website-deploy/recipes/default.rb
@@ -81,6 +81,18 @@ if mysql_node["rackspace"]
   mysql_address = mysql_node["rackspace"]["private_ip"]
 end
 
+memcache_nodes = search(:node, "name:drupal-memcache-server* AND chef_environment:#{node.chef_environment}")
+memcache_servers = memcache_nodes.map do |node|
+  if node["rackspace"]
+    node ["rackspace"]["private_ip"]
+  else
+    node["ipaddress"]
+  end
+end
+if memcache_servers.empty?
+  memcache_servers = ['localhost']
+end
+
 template "/var/www/theodi.org/sites/default/settings.php" do
   source "settings.php.erb"
   variables(
@@ -91,7 +103,7 @@ template "/var/www/theodi.org/sites/default/settings.php" do
   #    :db_host   => db[node.chef_environment]["host"],
       :db_host  => mysql_address,
       :db_driver => db[node.chef_environment]["driver"],
-      :memcache_servers => ["localhost"],
+      :memcache_servers => memcache_servers,
   )
   user "www-data"
   group "www-data"

--- a/site-cookbooks/odi-website-deploy/recipes/default.rb
+++ b/site-cookbooks/odi-website-deploy/recipes/default.rb
@@ -78,7 +78,8 @@ template "/var/www/theodi.org/sites/default/settings.php" do
       :db_user   => db[node.chef_environment]["username"],
       :db_pass   => db[node.chef_environment]["password"],
       :db_host   => db[node.chef_environment]["host"],
-      :db_driver => db[node.chef_environment]["driver"]
+      :db_driver => db[node.chef_environment]["driver"],
+      :memcache_servers => ["localhost"],
   )
   user "www-data"
   group "www-data"

--- a/site-cookbooks/odi-website-deploy/templates/default/settings.php.erb
+++ b/site-cookbooks/odi-website-deploy/templates/default/settings.php.erb
@@ -531,3 +531,10 @@ $conf['404_fast_html'] = '<html xmlns="http://www.w3.org/1999/xhtml"><head><titl
 
 $conf['cache_backends'][] = 'sites/all/modules/memcache/memcache.inc';
 $conf['cache_default_class'] = 'MemCacheDrupal';
+
+$conf['memcache_servers'] = array(
+  <% @memcache_servers.each do |memcache_server| %>
+    '<%= memcache_server %>:11211' => 'default',
+  <% end %>
+);
+$conf['memcache_bins'] = array('cache' => 'default')


### PR DESCRIPTION
Building on the feature-memcache branch, this adds the memcache configuration to the settings.php.

Currently untested and not using chef search, the server list is limited to localhost.
